### PR TITLE
add port specifications to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ You are welcomed to use the discussion board. [Discussions](https://github.com/q
   0. Make sure you are on Linux and have Docker installed
   1. Clone or download this repo
   2. Modify the json config files for your need. See the limited docs [below](#json-configs).
-  3. **Block access to ports 5672 and 15672 from the Internet using firewall such as ufw**
-  4. Make sure your current working directory and `PWD` both are the root of this repo
-  5. `docker compose up -d`
+  3. Make sure your current working directory and `PWD` both are the root of this repo
+  4. `docker compose up -d`
      - If you are updating, `docker compose down` and `docker compose pull` before `docker compose up -d`
-  6. Add this server to the BeatTogether mod's config. See [below](#beattogether-mod-configuration)
+  5. Add this server to the BeatTogether mod's config. See [below](#beattogether-mod-configuration)
 
 ## Json Configs
  - The options included here are not exhaustive but most likely what matters. 

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,11 +10,10 @@
   0. 确认你在使用Linux并且安装了Docker
   1. 克隆或者下载此仓库
   2. 按照你的需求修改json设置文件。 文档见[下方](#Json-设置文件).
-  3. **使用防火墙（比如ufw）屏蔽5672和15672端口的互联网访问**
-  4. 确认你的当前工作目录(current working directory) 和 `PWD` 都在这个仓库的根目录 
-  5. `docker compose up -d`
+  3. 确认你的当前工作目录(current working directory) 和 `PWD` 都在这个仓库的根目录 
+  4. `docker compose up -d`
      - 如果你在更新, 先 `docker compose down` 和 `docker compose pull` 再 `docker compose up -d`
-  6. 将这个服务器添加进BeatTogether mod的设置中。 详见[下方](#BeatTogether-Mod-设置)
+  5. 将这个服务器添加进BeatTogether mod的设置中。 详见[下方](#BeatTogether-Mod-设置)
 
 ## Json 设置文件
  - 这里并不包含全部的选项，下方仅包含了和开服相关的最重要的选项 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   rabbitmq:
     image: rabbitmq:3.9-management
     container_name: rabbitmq
-    network_mode: host
     restart: unless-stopped
     ports:
      - "127.0.0.1:5672:5672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     container_name: rabbitmq
     network_mode: host
     restart: unless-stopped
+    ports:
+     - "127.0.0.1:5672:5672"
+     - "127.0.0.1:15672:15672"
     healthcheck:
       test: rabbitmq-diagnostics -q ping
       interval: 10s
@@ -24,6 +27,8 @@ services:
       driver: json-file
       options:
         max-size: 4m
+    ports:
+     - "8989:8989"
     volumes:
       - ${PWD}/master.json:/app/appsettings.Production.json
       - ${PWD}/logs:/app/logs
@@ -60,6 +65,8 @@ services:
       driver: json-file
       options:
         max-size: 4m
+    ports:
+     - "23280:23280"
     volumes:
       - ${PWD}/api.json:/app/appsettings.Production.json
       - ${PWD}/logs:/app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,6 @@ services:
       driver: json-file
       options:
         max-size: 4m
-    ports:
-     - "8989:8989"
     volumes:
       - ${PWD}/master.json:/app/appsettings.Production.json
       - ${PWD}/logs:/app/logs
@@ -65,8 +63,6 @@ services:
       driver: json-file
       options:
         max-size: 4m
-    ports:
-     - "23280:23280"
     volumes:
       - ${PWD}/api.json:/app/appsettings.Production.json
       - ${PWD}/logs:/app/logs


### PR DESCRIPTION
this also firewalls/only exposes ports that shouldn't be exposed publicly (5672 and 15672) to localhost

also, removed firewall notice from installation notes as defining ports / constraining some to localhost only within docker-compose.yml makes this step unnecessary